### PR TITLE
fix: update quick-start URL to current path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Swarm](https://www.ethswarm.org/) is an incentivized peer-to-peer storage and communication system. [Join the decentralized network with a Bee node](https://docs.ethswarm.org/docs/installation/quick-start), the basic building block of Swarm.
+[Swarm](https://www.ethswarm.org/) is an incentivized peer-to-peer storage and communication system. [Join the decentralized network with a Bee node](https://docs.ethswarm.org/docs/bee/installation/quick-start), the basic building block of Swarm.
 
 This is a list of free and open source projects related to Swarm and its growing ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to create your submission.
 
 [Etherjot](https://github.com/ethersphere/etherjot) - Bring your web3 blog live in minutes with Etherjot, a graphical blogging application natively supporting Swarm.
 
-[buzzMint](buzz-mint.eth.limo) - A decentralised NFT creator.
+[buzzMint](https://buzzmint.io/) - A decentralised NFT creator.
 
 [Bchan](https://bchan.bzz.limo/) - A private message board allowing users to post images, text, and links across various threads.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to create your submission.
 
 [Fairdrive code](https://github.com/fairDataSociety/fairdrive-theapp) - Code for decentralised and unstoppable "Dropbox" for end-users and developers using Fair Data Protocol.
 
-[Galileo](https://app.galileo.fairdatasociety.org/) - Open Street Maps on Swarm.
 
 [SwarmScan](https://swarmscan.resenje.org/) - Get network insights.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to create your submission.
 
 [DeBoot](https://github.com/awmacpherson/deboot) - DeBoot is a project to research and implement approaches to bootloading OS images from a decentralized storage network such as Swarm or IPFS.
 
-[Swarm DAppNode Package](https://github.com/rndlabs/dappnodepackage-swarm) - Swarm DAppNode package for Swarm Mainnet with multi-platform (x86_64 and arm64) support. Testnet DAppNode packages can be found [here](https://github.com/rndlabs/dappnodepackage-swarm-testnet).
+[Swarm DAppNode Package](https://github.com/rndlabs/dappnodepackage-swarm) - Swarm DAppNode package for Swarm Mainnet with multi-platform (x86_64 and arm64) support.
 
 [Mipasa Swarm Connector](https://github.com/MiPasa/mipasa-swarm-connector/) - MiPasa connector for Swarm (BZZ) distributed storage network.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to create your submission.
 
 [buzzMint](https://buzzmint.io/) - A decentralised NFT creator.
 
-[Bchan](https://bchan.bzz.limo/) - A private message board allowing users to post images, text, and links across various threads.
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to create your submission.
 
 [Bee-JS Docs](https://github.com/ethersphere/bee-js-docs) - Documentation for the Swarm Bee-js javascript library. View at [bee-js.ethswarm.org](https://bee-js.ethswarm.org/docs/).
 
-[Swarm Specification](https://papers.ethswarm.org/p/swarm-specification/) - The Swarm specification document is an essential resource for developers and software engineers seeking to build their own Swarm client or integrate Swarm's functionalities into their applications.
+[Swarm Specification](https://papers.ethswarm.org/p/swarm-protocol-spec/) - The Swarm specification document is an essential resource for developers and software engineers seeking to build their own Swarm client or integrate Swarm's functionalities into their applications.
 
 [Swarm Erasure Coding paper](https://papers.ethswarm.org/p/erasure/) - The erasure coding paper provides a technical exploration of erasure coding in the Swarm network, focusing on ensuring data integrity and resilience.
 


### PR DESCRIPTION
The link to the Bee quick-start guide uses the old URL path `/docs/installation/quick-start` which returns a 404. The current path is `/docs/bee/installation/quick-start`.

## Change

```
- https://docs.ethswarm.org/docs/installation/quick-start
+ https://docs.ethswarm.org/docs/bee/installation/quick-start
```