### PR TITLE
Add bee-tui to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to create your submission.
 
 [IPFS to Swarm](https://github.com/Solar-Punk-Ltd/ipfs-to-swarm) - Migrate data from IPFS to Swarm.
 
+[bee-tui](https://github.com/ethswarm-tools/bee-tui) - k9s-style terminal cockpit for Bee operators with nine live screens, drill panes, and an always-on HTTP request tail.
+
 ### Smart Contracts
 
 **[`^ back to top ^`](#)**


### PR DESCRIPTION
Adds [bee-tui](https://github.com/ethswarm-tools/bee-tui) to the **Tools** section, alongside Doctor Bee / Beest / Swarm CLI.

**What it is:** a k9s-style terminal cockpit for Bee node operators. Nine live screens (Health gates, Stamps, SWAP, Lottery, Peers + bin saturation, Network/NAT, Warmup, RPC/API health, Tags) plus an always-on HTTP request tail and per-row drill panes for stamps (bucket histogram) and peers (balance / cheques / settlement / ping).

**Submission checklist** (per CONTRIBUTING.md):

- [x] One item per PR
- [x] Active project — v1.0.0 shipped 2026-05-07, [crates.io](https://crates.io/crates/bee-tui)
- [x] Related to Bee — built on top of bee-rs, queries Bee API 8.0.0
- [x] Format: `[Name](url) - description ≤160 chars, sentence case`
- [x] Free software — dual-licensed [Apache-2.0](https://github.com/ethswarm-tools/bee-tui/blob/main/LICENSE-APACHE) OR [MIT](https://github.com/ethswarm-tools/bee-tui/blob/main/LICENSE-MIT) at user's option

**Install:**

```sh
curl --proto '=https' --tlsv1.2 -LsSf \
  https://github.com/ethswarm-tools/bee-tui/releases/latest/download/bee-tui-installer.sh \
  | sh
```

Prebuilt binaries via cargo-dist for Linux / macOS / Windows on every release; no Rust toolchain required.